### PR TITLE
ci: Integrate MemBrowse

### DIFF
--- a/.github/membrowse-targets.json
+++ b/.github/membrowse-targets.json
@@ -1,0 +1,32 @@
+[
+  {
+    "target_name": "esp32-server",
+    "port": "esp32",
+    "board": "server",
+    "setup_cmd": ". ${IDF_PATH}/export.sh && (cd libssh && ./install.sh)",
+    "build_cmd": ". ${IDF_PATH}/export.sh && cd libssh/examples/server && idf.py build",
+    "elf": "libssh/examples/server/build/server.elf",
+    "ld": "libssh/examples/server/build/esp-idf/esp_system/ld/memory.ld",
+    "linker_vars": ""
+  },
+  {
+    "target_name": "esp32-esp_ssh",
+    "port": "esp32",
+    "board": "esp_ssh",
+    "setup_cmd": ". ${IDF_PATH}/export.sh && (cd libssh && ./install.sh)",
+    "build_cmd": ". ${IDF_PATH}/export.sh && cd libssh/examples/esp_ssh && idf.py build",
+    "elf": "libssh/examples/esp_ssh/build/server.elf",
+    "ld": "libssh/examples/esp_ssh/build/esp-idf/esp_system/ld/memory.ld",
+    "linker_vars": ""
+  },
+  {
+    "target_name": "esp32-bastion",
+    "port": "esp32",
+    "board": "bastion",
+    "setup_cmd": ". ${IDF_PATH}/export.sh && (cd libssh && ./install.sh)",
+    "build_cmd": ". ${IDF_PATH}/export.sh && cd libssh/examples/bastion && idf.py build",
+    "elf": "libssh/examples/bastion/build/bastion_ssh.elf",
+    "ld": "libssh/examples/bastion/build/esp-idf/esp_system/ld/memory.ld",
+    "linker_vars": ""
+  }
+]

--- a/.github/workflows/membrowse-comment.yml
+++ b/.github/workflows/membrowse-comment.yml
@@ -1,0 +1,68 @@
+name: Membrowse PR Comment
+
+on:
+  workflow_run:
+    workflows: [Membrowse Memory Report]
+    types: [completed]
+
+permissions:
+  contents: read
+  actions: read
+  pull-requests: write
+
+jobs:
+  comment:
+    runs-on: ubuntu-22.04
+    if: github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.conclusion == 'success'
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+
+      - name: Download report artifacts
+        id: download-reports
+        uses: actions/github-script@v7
+        with:
+          result-encoding: string
+          script: |
+            const fs = require('fs');
+
+            const allArtifacts = await github.rest.actions.listWorkflowRunArtifacts({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              run_id: context.payload.workflow_run.id,
+            });
+
+            const reportArtifacts = allArtifacts.data.artifacts.filter(
+              artifact => artifact.name.startsWith('membrowse-report-')
+            );
+
+            if (reportArtifacts.length === 0) {
+              console.log('No report artifacts found');
+              return 'skip';
+            }
+
+            fs.mkdirSync('reports', { recursive: true });
+
+            for (const artifact of reportArtifacts) {
+              console.log(`Downloading ${artifact.name}...`);
+              const download = await github.rest.actions.downloadArtifact({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                artifact_id: artifact.id,
+                archive_format: 'zip',
+              });
+
+              const zipPath = `${artifact.name}.zip`;
+              fs.writeFileSync(zipPath, Buffer.from(download.data));
+              await exec.exec('unzip', ['-o', zipPath, '-d', 'reports']);
+            }
+
+            return 'ok';
+
+      - name: Post combined PR comment
+        if: steps.download-reports.outputs.result == 'ok'
+        uses: membrowse/membrowse-action/comment-action@v1
+        with:
+          json_files: "reports/*.json"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/membrowse-onboard.yml
+++ b/.github/workflows/membrowse-onboard.yml
@@ -1,0 +1,97 @@
+name: Onboard to Membrowse
+
+on:
+  workflow_dispatch:
+    inputs:
+      num_commits:
+        description: 'Number of commits to process'
+        required: true
+        default: '100'
+        type: string
+
+jobs:
+  load-targets:
+    runs-on: ubuntu-22.04
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+
+      - name: Load target matrix
+        id: set-matrix
+        run: echo "matrix=$(jq -c '.' .github/membrowse-targets.json)" >> $GITHUB_OUTPUT
+
+  onboard:
+    needs: load-targets
+    runs-on: ubuntu-22.04
+    strategy:
+      fail-fast: false
+      matrix:
+        include: ${{ fromJson(needs.load-targets.outputs.matrix) }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+          submodules: recursive
+
+      - name: Install ESP-IDF dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y git wget flex bison gperf python3 python3-pip python3-venv cmake ninja-build ccache libffi-dev libssl-dev dfu-util libusb-1.0-0
+
+      - name: Clone and install ESP-IDF
+        run: |
+          git clone -b release/v5.5 --depth 1 --recursive https://github.com/espressif/esp-idf.git /home/runner/esp-idf
+          /home/runner/esp-idf/install.sh esp32
+          # Find and record the actual venv path
+          VENV_PATH=$(find /home/runner/.espressif/python_env -name "activate" -path "*/bin/*" 2>/dev/null | head -1 | xargs dirname)
+          echo "ESP_IDF_VENV=$VENV_PATH" >> $GITHUB_ENV
+          echo "Found venv at: $VENV_PATH"
+
+      - name: Set ESP-IDF environment globally
+        run: |
+          . /home/runner/esp-idf/export.sh
+          echo "$PATH" | tr ':' '\n' | grep -E "(espressif|esp-idf)" >> $GITHUB_PATH
+          echo "IDF_PATH=/home/runner/esp-idf" >> $GITHUB_ENV
+          which idf.py
+
+      - name: Download libssh source
+        run: |
+          cd libssh && ./install.sh
+          mv libssh-0.11.0 /home/runner/libssh-0.11.0
+
+      - name: Create build script
+        run: |
+          cat > /tmp/build.sh << 'EOF'
+          #!/bin/bash
+          set -e
+          . $ESP_IDF_VENV/activate
+          export IDF_PATH=/home/runner/esp-idf
+          . $IDF_PATH/export.sh 2>/dev/null || true
+          if [ ! -d "libssh/examples/$1" ]; then
+            echo "Example $1 not found in this commit, skipping"
+            exit 0
+          fi
+          # Symlink libssh source (stored outside repo to survive git checkouts)
+          ln -sfn /home/runner/libssh-0.11.0 libssh/libssh-0.11.0
+          cd libssh/examples/$1
+          idf.py build
+          EOF
+          chmod +x /tmp/build.sh
+
+      - name: Run Membrowse Onboard Action
+        env:
+          ESP_IDF_VENV: ${{ env.ESP_IDF_VENV }}
+        uses: membrowse/membrowse-action/onboard-action@v1
+        with:
+          target_name: ${{ matrix.target_name }}
+          num_commits: ${{ github.event.inputs.num_commits }}
+          build_script: /tmp/build.sh ${{ matrix.board }}
+          elf: ${{ matrix.elf }}
+          ld: ${{ matrix.ld }}
+          linker_vars: ${{ matrix.linker_vars }}
+          api_key: ${{ secrets.MEMBROWSE_API_KEY }}
+          api_url: ${{ vars.MEMBROWSE_API_URL }}

--- a/.github/workflows/membrowse-report.yml
+++ b/.github/workflows/membrowse-report.yml
@@ -1,0 +1,103 @@
+name: Membrowse Memory Report
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  load-targets:
+    runs-on: ubuntu-22.04
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+
+      - name: Load target matrix
+        id: set-matrix
+        run: echo "matrix=$(jq -c '.' .github/membrowse-targets.json)" >> $GITHUB_OUTPUT
+
+  build:
+    needs: load-targets
+    runs-on: ubuntu-22.04
+    container: espressif/idf:release-v5.5
+    strategy:
+      fail-fast: false
+      matrix:
+        include: ${{ fromJson(needs.load-targets.outputs.matrix) }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+          submodules: recursive
+
+      - name: Setup and build
+        shell: bash
+        run: |
+          for i in 1 2 3; do
+            ${{ matrix.setup_cmd }} && break
+            echo "Setup attempt $i failed, retrying..."
+            sleep 5
+          done
+          ${{ matrix.build_cmd }}
+
+      - name: Upload ELF artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: elf-${{ matrix.target_name }}
+          path: ${{ matrix.elf }}
+
+  analyze:
+    needs: [load-targets, build]
+    runs-on: ubuntu-22.04
+    strategy:
+      fail-fast: false
+      matrix:
+        include: ${{ fromJson(needs.load-targets.outputs.matrix) }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Download ELF artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: elf-${{ matrix.target_name }}
+          path: elf-download
+
+      - name: Prepare ELF path
+        id: elf
+        run: |
+          mkdir -p $(dirname "${{ matrix.elf }}")
+          mv elf-download/*.elf "${{ matrix.elf }}"
+          echo "path=${{ matrix.elf }}" >> $GITHUB_OUTPUT
+
+      - name: Run Membrowse PR Action
+        id: analyze
+        continue-on-error: true
+        uses: membrowse/membrowse-action@v1
+        with:
+          target_name: ${{ matrix.target_name }}
+          elf: ${{ steps.elf.outputs.path }}
+          ld: ${{ matrix.ld }}
+          linker_vars: ${{ matrix.linker_vars }}
+          api_key: ${{ secrets.MEMBROWSE_API_KEY }}
+          api_url: ${{ vars.MEMBROWSE_API_URL }}
+          verbose: INFO
+
+      - name: Upload report artifact
+        if: ${{ steps.analyze.outcome == 'success' }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: membrowse-report-${{ matrix.target_name }}
+          path: ${{ steps.analyze.outputs.report_path }}

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # libssh
 
+[![Membrowse](https://membrowse.com/badge.svg)](https://membrowse.com/public/david-cermak/libssh)
+
 A minimal ESP-IDF port of libssh.
 The purpose of this component is to provide a way to run `sshd` on your ESP32 device, so you can "ssh" into your device.
 


### PR DESCRIPTION
As discussed, this PR adds a MemBrowse integration to libssh.

The integration is wired into the existing CI tests, so it can be used to collect both historical and ongoing memory footprint data.

The targets are defined membrowse-targets.json.

For historical data, the membrowse-onboard.yml workflow needs to be run manually. In this PR, I ran it from my fork to upload the last 25 commits, which are visible here:
https://membrowse.com/public/membrowse/libssh

Ongoing reporting works as follows:

membrowse-report.yaml runs on every PR update and on pushes to main
It builds the configured targets, analyzes the resulting ELFs, and uploads the results to MemBrowse
A summary of memory changes is posted directly as a PR comment via membrowse-comment.yaml

For the upload to work:

- Create an account in membrowse.com
- Create a project
- Take the api key and put as MEMBROWSE_API_KEY github secret
- In the project config in membrowse.com set the project dashboard to be available publicly.
