### PR TITLE
feat(libssh): Update to support v0.12 upstream

### DIFF
--- a/libssh/CMakeLists.txt
+++ b/libssh/CMakeLists.txt
@@ -64,13 +64,19 @@ ${libssh_SRCS}
     md_mbedcrypto.c
     dh_key.c
     pki_ed25519.c
-    sntrup761.c
     external/ed25519.c
     external/fe25519.c
     external/ge25519.c
     external/sc25519.c
+)
+
+if(CONFIG_LIBSSH_SNTRUP761)
+set(libssh_SRCS
+${libssh_SRCS}
+    sntrup761.c
     external/sntrup761.c
 )
+endif()
 
 set(libssh_SRCS
 ${libssh_SRCS}

--- a/libssh/CMakeLists.txt
+++ b/libssh/CMakeLists.txt
@@ -1,4 +1,4 @@
-set(LIBSSH_VERSION "0.11.0")
+set(LIBSSH_VERSION "0.12.0")
 set(LIBSSH_DIR "libssh-${LIBSSH_VERSION}")
 
 set(libssh_SRCS
@@ -29,12 +29,14 @@ set(libssh_SRCS
   match.c
   messages.c
   misc.c
+  mlkem.c
   options.c
   packet.c
   packet_cb.c
   packet_crypt.c
   pcap.c
   pki.c
+  pki_context.c
   pki_container_openssh.c
   poll.c
   session.c
@@ -44,6 +46,7 @@ set(libssh_SRCS
   threads.c
   ttyopts.c
   wrapper.c
+  gzip.c
   external/bcrypt_pbkdf.c
   external/blowfish.c
   config_parser.c
@@ -62,10 +65,13 @@ ${libssh_SRCS}
     md_mbedcrypto.c
     dh_key.c
     pki_ed25519.c
+    hybrid_mlkem.c
+    sntrup761.c
     external/ed25519.c
     external/fe25519.c
     external/ge25519.c
     external/sc25519.c
+    external/sntrup761.c
 )
 
 set(libssh_SRCS
@@ -90,7 +96,14 @@ ${libssh_SRCS}
 
 set(libssh_SRCS
 ${libssh_SRCS}
+    curve25519_fallback.c
     external/curve25519_ref.c
+)
+
+set(libssh_SRCS
+${libssh_SRCS}
+    mlkem_native.c
+    external/libcrux_mlkem768_sha3.c
 )
 
 list(TRANSFORM libssh_SRCS PREPEND "${LIBSSH_DIR}/src/")
@@ -114,3 +127,4 @@ endif()
 
 set_source_files_properties(${LIBSSH_DIR}/src/external/bcrypt_pbkdf.c PROPERTIES COMPILE_OPTIONS "-Wno-unterminated-string-initialization")
 set_source_files_properties(${LIBSSH_DIR}/src/external/chacha.c PROPERTIES COMPILE_OPTIONS "-Wno-unterminated-string-initialization")
+set_source_files_properties(${LIBSSH_DIR}/src/external/libcrux_mlkem768_sha3.c PROPERTIES COMPILE_OPTIONS "-Wno-declaration-after-statement")

--- a/libssh/CMakeLists.txt
+++ b/libssh/CMakeLists.txt
@@ -29,7 +29,6 @@ set(libssh_SRCS
   match.c
   messages.c
   misc.c
-  mlkem.c
   options.c
   packet.c
   packet_cb.c
@@ -65,7 +64,6 @@ ${libssh_SRCS}
     md_mbedcrypto.c
     dh_key.c
     pki_ed25519.c
-    hybrid_mlkem.c
     sntrup761.c
     external/ed25519.c
     external/fe25519.c
@@ -100,11 +98,15 @@ ${libssh_SRCS}
     external/curve25519_ref.c
 )
 
+if(CONFIG_LIBSSH_MLKEM)
 set(libssh_SRCS
 ${libssh_SRCS}
+    mlkem.c
+    hybrid_mlkem.c
     mlkem_native.c
     external/libcrux_mlkem768_sha3.c
 )
+endif()
 
 list(TRANSFORM libssh_SRCS PREPEND "${LIBSSH_DIR}/src/")
 
@@ -127,4 +129,6 @@ endif()
 
 set_source_files_properties(${LIBSSH_DIR}/src/external/bcrypt_pbkdf.c PROPERTIES COMPILE_OPTIONS "-Wno-unterminated-string-initialization")
 set_source_files_properties(${LIBSSH_DIR}/src/external/chacha.c PROPERTIES COMPILE_OPTIONS "-Wno-unterminated-string-initialization")
+if(CONFIG_LIBSSH_MLKEM)
 set_source_files_properties(${LIBSSH_DIR}/src/external/libcrux_mlkem768_sha3.c PROPERTIES COMPILE_OPTIONS "-Wno-declaration-after-statement")
+endif()

--- a/libssh/Kconfig
+++ b/libssh/Kconfig
@@ -1,0 +1,16 @@
+menu "libssh"
+
+    config LIBSSH_MLKEM
+        bool "Enable ML-KEM (post-quantum) key exchange"
+        default n
+        help
+            Enable ML-KEM (Module-Lattice-based Key Exchange Mechanism)
+            hybrid key exchange algorithms: mlkem768x25519-sha256 and
+            mlkem768nistp256-sha256.
+
+            The ML-KEM implementation adds significant code size (~80 KB)
+            and stack usage (~40 KB) due to the libcrux cryptographic
+            library. Disable to reduce the memory footprint on
+            constrained devices.
+
+endmenu

--- a/libssh/Kconfig
+++ b/libssh/Kconfig
@@ -1,5 +1,14 @@
 menu "libssh"
 
+    config LIBSSH_SNTRUP761
+        bool "Enable SNTRUP761 (post-quantum) key exchange"
+        default n
+        help
+            Enable the sntrup761x25519-sha512 hybrid key exchange
+            algorithm. This adds significant stack usage due to the
+            SNTRUP761 cryptographic operations. Disable to reduce the
+            memory footprint on constrained devices.
+
     config LIBSSH_MLKEM
         bool "Enable ML-KEM (post-quantum) key exchange"
         default n

--- a/libssh/install.sh
+++ b/libssh/install.sh
@@ -1,16 +1,17 @@
 #!/bin/bash
 
 # libssh installation script
-# This script downloads, extracts, and builds libssh from source
+# This script downloads, extracts, and patches libssh for the ESP-IDF port
 
 set -e  # Exit on any error
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 
 # Configuration
 LIBSSH_VERSION="0.12.0"
 LIBSSH_URL="https://git.libssh.org/projects/libssh.git/snapshot/libssh-${LIBSSH_VERSION}.tar.xz"
 LIBSSH_DIR="libssh-${LIBSSH_VERSION}"
-INSTALL_DIR="/usr/local"
-
+PATCH_DIR="${SCRIPT_DIR}/patches"
 
 echo "Downloading libssh ${LIBSSH_VERSION}..."
 
@@ -29,3 +30,17 @@ if ! tar -xf "libssh-${LIBSSH_VERSION}.tar.xz"; then
 fi
 
 rm "libssh-${LIBSSH_VERSION}.tar.xz"
+
+# Apply ESP-IDF port patches
+if [ -d "${PATCH_DIR}" ]; then
+    for patch_file in "${PATCH_DIR}"/*.patch; do
+        [ -f "$patch_file" ] || continue
+        echo "Applying patch: $(basename "$patch_file")..."
+        if ! patch -p0 < "$patch_file"; then
+            echo "Failed to apply patch: $(basename "$patch_file")"
+            exit 1
+        fi
+    done
+fi
+
+echo "libssh ${LIBSSH_VERSION} installed successfully."

--- a/libssh/install.sh
+++ b/libssh/install.sh
@@ -6,7 +6,7 @@
 set -e  # Exit on any error
 
 # Configuration
-LIBSSH_VERSION="0.11.0"
+LIBSSH_VERSION="0.12.0"
 LIBSSH_URL="https://git.libssh.org/projects/libssh.git/snapshot/libssh-${LIBSSH_VERSION}.tar.xz"
 LIBSSH_DIR="libssh-${LIBSSH_VERSION}"
 INSTALL_DIR="/usr/local"

--- a/libssh/patches/esp_idf_port.patch
+++ b/libssh/patches/esp_idf_port.patch
@@ -1,5 +1,16 @@
+--- libssh-0.12.0/include/libssh/sntrup761.h	2026-02-10 10:35:23.000000000 +0100
++++ libssh-0.12.0/include/libssh/sntrup761.h	2026-04-10 18:22:41.362169147 +0200
+@@ -31,7 +31,7 @@
+ extern "C" {
+ #endif
+
+-#ifdef HAVE_CURVE25519
++#if defined(HAVE_CURVE25519) && !defined(WITHOUT_SNTRUP761)
+ #define HAVE_SNTRUP761 1
+ #endif
+
 --- libssh-0.12.0/src/kex.c	2026-02-10 10:35:23.000000000 +0100
-+++ libssh-0.12.0/src/kex.c	2026-04-10 17:23:06.447556919 +0200
++++ libssh-0.12.0/src/kex.c	2026-04-10 18:10:37.885707940 +0200
 @@ -105,6 +105,7 @@
  #define SNTRUP761X25519 ""
  #endif /* HAVE_SNTRUP761 */
@@ -101,7 +112,7 @@
          k_string = ssh_make_bignum_string(crypto->shared_secret);
          break;
 --- libssh-0.12.0/src/client.c	2026-02-10 10:35:23.000000000 +0100
-+++ libssh-0.12.0/src/client.c	2026-04-10 17:22:01.701215348 +0200
++++ libssh-0.12.0/src/client.c	2026-04-10 18:10:37.885707940 +0200
 @@ -306,6 +306,7 @@
              rc = ssh_client_sntrup761x25519_init(session);
              break;
@@ -119,7 +130,7 @@
              rc = SSH_ERROR;
          }
 --- libssh-0.12.0/src/wrapper.c	2026-02-10 10:35:23.000000000 +0100
-+++ libssh-0.12.0/src/wrapper.c	2026-04-10 17:22:08.481167368 +0200
++++ libssh-0.12.0/src/wrapper.c	2026-04-10 18:10:37.885707940 +0200
 @@ -625,6 +625,7 @@
          ssh_server_sntrup761x25519_init(session);
          break;

--- a/libssh/patches/esp_idf_port.patch
+++ b/libssh/patches/esp_idf_port.patch
@@ -1,0 +1,138 @@
+--- libssh-0.12.0/src/kex.c	2026-02-10 10:35:23.000000000 +0100
++++ libssh-0.12.0/src/kex.c	2026-04-10 17:23:06.447556919 +0200
+@@ -105,6 +105,7 @@
+ #define SNTRUP761X25519 ""
+ #endif /* HAVE_SNTRUP761 */
+
++#ifdef HAVE_MLKEM
+ #ifdef HAVE_MLKEM1024
+ #define HYBRID_MLKEM "mlkem768x25519-sha256," \
+                      "mlkem768nistp256-sha256," \
+@@ -113,6 +114,9 @@
+ #define HYBRID_MLKEM "mlkem768x25519-sha256," \
+                      "mlkem768nistp256-sha256,"
+ #endif /* HAVE_MLKEM1024 */
++#else
++#define HYBRID_MLKEM ""
++#endif /* HAVE_MLKEM */
+
+ #ifdef HAVE_ECC
+ #define ECDH "ecdh-sha2-nistp256,ecdh-sha2-nistp384,ecdh-sha2-nistp521,"
+@@ -995,6 +999,7 @@
+         return SSH_KEX_SNTRUP761X25519_SHA512_OPENSSH_COM;
+     } else if (strcmp(kex, "sntrup761x25519-sha512") == 0) {
+         return SSH_KEX_SNTRUP761X25519_SHA512;
++#ifdef HAVE_MLKEM
+     } else if (strcmp(kex, "mlkem768x25519-sha256") == 0) {
+         return SSH_KEX_MLKEM768X25519_SHA256;
+     } else if (strcmp(kex, "mlkem768nistp256-sha256") == 0) {
+@@ -1003,6 +1008,7 @@
+     } else if (strcmp(kex, "mlkem1024nistp384-sha384") == 0) {
+         return SSH_KEX_MLKEM1024NISTP384_SHA384;
+ #endif
++#endif /* HAVE_MLKEM */
+     }
+     /* should not happen. We should be getting only valid names at this stage */
+     return 0;
+@@ -1057,6 +1063,7 @@
+         ssh_client_sntrup761x25519_remove_callbacks(session);
+         break;
+ #endif
++#ifdef HAVE_MLKEM
+     case SSH_KEX_MLKEM768X25519_SHA256:
+     case SSH_KEX_MLKEM768NISTP256_SHA256:
+ #ifdef HAVE_MLKEM1024
+@@ -1064,6 +1071,9 @@
+ #endif
+         ssh_client_hybrid_mlkem_remove_callbacks(session);
+         break;
++#endif /* HAVE_MLKEM */
++    default:
++        break;
+     }
+ }
+
+@@ -1663,6 +1673,7 @@
+         }
+         break;
+ #endif /* HAVE_SNTRUP761 */
++#ifdef HAVE_MLKEM
+     case SSH_KEX_MLKEM768X25519_SHA256:
+     case SSH_KEX_MLKEM768NISTP256_SHA256:
+ #ifdef HAVE_MLKEM1024
+@@ -1679,6 +1690,7 @@
+             goto error;
+         }
+         break;
++#endif /* HAVE_MLKEM */
+     default:
+         /* Handle unsupported kex types - this should not happen in normal operation */
+         rc = SSH_ERROR;
+@@ -1693,6 +1705,7 @@
+                              session->next_crypto->shared_secret,
+                              SHA512_DIGEST_LEN);
+         break;
++#ifdef HAVE_MLKEM
+     case SSH_KEX_MLKEM768X25519_SHA256:
+     case SSH_KEX_MLKEM768NISTP256_SHA256:
+ #ifdef HAVE_MLKEM1024
+@@ -1700,6 +1713,7 @@
+ #endif
+         rc = ssh_buffer_pack(buf, "S", session->next_crypto->hybrid_shared_secret);
+         break;
++#endif /* HAVE_MLKEM */
+     default:
+         rc = ssh_buffer_pack(buf, "B", session->next_crypto->shared_secret);
+         break;
+@@ -1922,6 +1936,7 @@
+         k_string = ssh_make_padded_bignum_string(crypto->shared_secret,
+                                                  crypto->digest_len);
+         break;
++#ifdef HAVE_MLKEM
+     case SSH_KEX_MLKEM768X25519_SHA256:
+     case SSH_KEX_MLKEM768NISTP256_SHA256:
+ #ifdef HAVE_MLKEM1024
+@@ -1929,6 +1944,7 @@
+ #endif
+         k_string = ssh_string_copy(crypto->hybrid_shared_secret);
+         break;
++#endif /* HAVE_MLKEM */
+     default:
+         k_string = ssh_make_bignum_string(crypto->shared_secret);
+         break;
+--- libssh-0.12.0/src/client.c	2026-02-10 10:35:23.000000000 +0100
++++ libssh-0.12.0/src/client.c	2026-04-10 17:22:01.701215348 +0200
+@@ -306,6 +306,7 @@
+             rc = ssh_client_sntrup761x25519_init(session);
+             break;
+ #endif
++#ifdef HAVE_MLKEM
+         case SSH_KEX_MLKEM768X25519_SHA256:
+         case SSH_KEX_MLKEM768NISTP256_SHA256:
+ #ifdef HAVE_MLKEM1024
+@@ -313,6 +314,7 @@
+ #endif
+             rc = ssh_client_hybrid_mlkem_init(session);
+             break;
++#endif /* HAVE_MLKEM */
+         default:
+             rc = SSH_ERROR;
+         }
+--- libssh-0.12.0/src/wrapper.c	2026-02-10 10:35:23.000000000 +0100
++++ libssh-0.12.0/src/wrapper.c	2026-04-10 17:22:08.481167368 +0200
+@@ -625,6 +625,7 @@
+         ssh_server_sntrup761x25519_init(session);
+         break;
+ #endif
++#ifdef HAVE_MLKEM
+     case SSH_KEX_MLKEM768X25519_SHA256:
+     case SSH_KEX_MLKEM768NISTP256_SHA256:
+ #ifdef HAVE_MLKEM1024
+@@ -632,6 +633,7 @@
+ #endif
+         ssh_server_hybrid_mlkem_init(session);
+         break;
++#endif /* HAVE_MLKEM */
+     default:
+         ssh_set_error(session,
+                       SSH_FATAL,

--- a/libssh/port/config.h
+++ b/libssh/port/config.h
@@ -260,6 +260,11 @@
 /* Define to 1 if you want to enable calltrace debug output */
 #define DEBUG_CALLTRACE 1
 
+/* Define to 1 if you want to enable ML-KEM hybrid key exchange */
+#ifdef CONFIG_LIBSSH_MLKEM
+#define HAVE_MLKEM 1
+#endif
+
 /* Define to 1 if you want to enable NaCl support */
 /* #undef WITH_NACL */
 

--- a/libssh/port/config.h
+++ b/libssh/port/config.h
@@ -260,6 +260,11 @@
 /* Define to 1 if you want to enable calltrace debug output */
 #define DEBUG_CALLTRACE 1
 
+/* Define to 1 if you want to enable SNTRUP761 hybrid key exchange */
+#ifndef CONFIG_LIBSSH_SNTRUP761
+#define WITHOUT_SNTRUP761 1
+#endif
+
 /* Define to 1 if you want to enable ML-KEM hybrid key exchange */
 #ifdef CONFIG_LIBSSH_MLKEM
 #define HAVE_MLKEM 1

--- a/libssh/port/config.h
+++ b/libssh/port/config.h
@@ -4,14 +4,15 @@
 #define PACKAGE "libssh"
 
 /* Version number of package */
-#define VERSION "0.11.0"
+#define VERSION "0.12.0"
 
 #define SYSCONFDIR "etc"
-#define BINARYDIR "/home/david/repos/libssh-0.11.0/build_minimal"
-#define SOURCEDIR "/home/david/repos/libssh-0.11.0"
+#define BINARYDIR "/home/david/repos/libssh-0.12.0/build_minimal"
+#define SOURCEDIR "/home/david/repos/libssh-0.12.0"
 
 /* Global bind configuration file path */
 #define GLOBAL_BIND_CONFIG "/etc/ssh/libssh_server_config"
+#define GLOBAL_CONF_DIR "/etc/ssh"
 
 /* Global client configuration file path */
 #define GLOBAL_CLIENT_CONFIG "/etc/ssh/ssh_config"

--- a/libssh/port/idf_compat.h
+++ b/libssh/port/idf_compat.h
@@ -16,6 +16,7 @@ int socketpair(int domain, int type, int protocol, int sv[2]);
 
 // socket utils
 #define PF_UNIX AF_UNIX
+#define NI_NUMERICHOST AI_NUMERICHOST
 
 // termios
 #ifndef IMAXBEL


### PR DESCRIPTION
Adds support for [v0.12](https://www.libssh.org/files/0.12)
---

# libssh ESP-IDF Memory Stats per Algorithm

Tested on **ESP32**, IDF v5.5, server example with password auth.
`CONFIG_ESP_MAIN_TASK_STACK_SIZE=46000`. Host key: ed25519. Cipher: chacha20-poly1305.

## Flash Footprint (liblibssh.a)

| Config | Kconfig | Flash Code | Flash Data | DRAM | Total | Delta |
|--------|---------|------------|------------|------|-------|-------|
| Both PQC disabled | SNTRUP=n, MLKEM=n | 107,660 | 119,632 | 10,092 | **237,384** | baseline |
| SNTRUP761 only | SNTRUP=y, MLKEM=n | 116,001 | 119,768 | 10,124 | **245,893** | +8,509 |
| ML-KEM only | SNTRUP=n, MLKEM=y | 137,133 | 125,172 | 10,124 | **272,429** | +35,045 |
| Both PQC enabled | SNTRUP=y, MLKEM=y | 145,490 | 125,308 | 10,156 | **280,954** | +43,570 |


**Incremental cost:**
- SNTRUP761 adds ~8.5 KB (mostly code)
- ML-KEM adds ~35 KB on top of SNTRUP761 (libcrux library)

## Runtime Stack Usage (peak, during KEX)

| Negotiated KEX | Stack HWM (free) | Peak Stack Used | KEX Stack Cost | Margin |
|----------------|-------------------|-----------------|----------------|--------|
| curve25519-sha256 | 40,300 | 5,700 | ~2.0 KB | 40,300 |
| sntrup761x25519-sha512 | **60** | 45,940 | ~42.2 KB | **60** |
| mlkem768x25519-sha256 | 7,004 | 38,996 | ~35.2 KB | 7,004 |

Stack HWM measured at "session ready" phase (after KEX + auth + channel open).
Baseline stack usage before KEX is ~3,764 bytes; KEX Stack Cost = Peak - Baseline.

**Key takeaway:** SNTRUP761 nearly exhausts a 46 KB stack (60 bytes remaining!).
ML-KEM is heavy but safer with ~7 KB margin on a 46 KB stack.
curve25519 is lightweight at ~6 KB peak.

## Runtime Heap Usage

| Phase | curve25519 | sntrup761 | mlkem768x25519 |
|-------|-----------|-----------|----------------|
| Before ssh_init (free) | 171,608 | 171,576 | 171,532 |
| After ssh_init (free) | 168,920 | 168,888 | 168,840 |
| After session accepted (free) | 163,140 | 158,684 | 158,636 |
| Session ready (free) | 144,080 | 133,540 | 128,712 |
| **Min free heap ever** | **138,996** | **130,652** | **121,372** |

| Metric | curve25519 | sntrup761 | mlkem768x25519 |
|--------|-----------|-----------|----------------|
| ssh_init heap cost | 2,688 | 2,688 | 2,692 |
| Session accept heap cost | 5,780 | 10,204 | 10,204 |
| KEX + auth + channel heap | 19,060 | 25,144 | 29,924 |
| **Total heap (init → ready)** | **27,528** | **38,036** | **42,820** |
| **Peak heap (init → min ever)** | **32,612** | **40,924** | **50,160** |

**Summary:** ML-KEM uses ~18 KB more peak heap than curve25519;
SNTRUP761 uses ~8 KB more. Both PQC algorithms allocate extra buffers
for the hybrid key exchange (public keys, ciphertexts, shared secrets).

## Recommendations for Constrained Devices

| Scenario | Recommended config | Min stack | Notes |
|----------|-------------------|-----------|-------|
| Smallest footprint | Both PQC off | ~8 KB | No post-quantum protection |
| Post-quantum, tight memory | ML-KEM only | ~46 KB | Best PQC-to-stack ratio |
| Post-quantum, OpenSSH compat | SNTRUP761 only | ~48 KB+ | Dangerously tight at 46 KB |
| Maximum compatibility | Both PQC on | ~48 KB+ | ML-KEM preferred by modern clients |

