### PR TITLE
ci: MemBrowse integration fix and added library breakdown support

### DIFF
--- a/.github/membrowse-targets.json
+++ b/.github/membrowse-targets.json
@@ -6,6 +6,7 @@
     "setup_cmd": ". ${IDF_PATH}/export.sh && (cd libssh && ./install.sh)",
     "build_cmd": ". ${IDF_PATH}/export.sh && cd libssh/examples/server && idf.py build",
     "elf": "libssh/examples/server/build/server.elf",
+    "map": "libssh/examples/server/build/server.map",
     "ld": "libssh/examples/server/build/esp-idf/esp_system/ld/memory.ld",
     "linker_vars": ""
   },
@@ -16,6 +17,7 @@
     "setup_cmd": ". ${IDF_PATH}/export.sh && (cd libssh && ./install.sh)",
     "build_cmd": ". ${IDF_PATH}/export.sh && cd libssh/examples/esp_ssh && idf.py build",
     "elf": "libssh/examples/esp_ssh/build/server.elf",
+    "map": "libssh/examples/esp_ssh/build/server.map",
     "ld": "libssh/examples/esp_ssh/build/esp-idf/esp_system/ld/memory.ld",
     "linker_vars": ""
   },
@@ -26,6 +28,7 @@
     "setup_cmd": ". ${IDF_PATH}/export.sh && (cd libssh && ./install.sh)",
     "build_cmd": ". ${IDF_PATH}/export.sh && cd libssh/examples/bastion && idf.py build",
     "elf": "libssh/examples/bastion/build/bastion_ssh.elf",
+    "map": "libssh/examples/bastion/build/bastion_ssh.map",
     "ld": "libssh/examples/bastion/build/esp-idf/esp_system/ld/memory.ld",
     "linker_vars": ""
   }

--- a/.github/workflows/membrowse-comment.yml
+++ b/.github/workflows/membrowse-comment.yml
@@ -6,8 +6,6 @@ on:
     types: [completed]
 
 permissions:
-  contents: read
-  actions: read
   pull-requests: write
 
 jobs:
@@ -15,54 +13,11 @@ jobs:
     runs-on: ubuntu-22.04
     if: github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.conclusion == 'success'
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v5
-
-      - name: Download report artifacts
-        id: download-reports
-        uses: actions/github-script@v7
-        with:
-          result-encoding: string
-          script: |
-            const fs = require('fs');
-
-            const allArtifacts = await github.rest.actions.listWorkflowRunArtifacts({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              run_id: context.payload.workflow_run.id,
-            });
-
-            const reportArtifacts = allArtifacts.data.artifacts.filter(
-              artifact => artifact.name.startsWith('membrowse-report-')
-            );
-
-            if (reportArtifacts.length === 0) {
-              console.log('No report artifacts found');
-              return 'skip';
-            }
-
-            fs.mkdirSync('reports', { recursive: true });
-
-            for (const artifact of reportArtifacts) {
-              console.log(`Downloading ${artifact.name}...`);
-              const download = await github.rest.actions.downloadArtifact({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                artifact_id: artifact.id,
-                archive_format: 'zip',
-              });
-
-              const zipPath = `${artifact.name}.zip`;
-              fs.writeFileSync(zipPath, Buffer.from(download.data));
-              await exec.exec('unzip', ['-o', zipPath, '-d', 'reports']);
-            }
-
-            return 'ok';
-
-      - name: Post combined PR comment
-        if: steps.download-reports.outputs.result == 'ok'
+      - name: Post PR comment
         uses: membrowse/membrowse-action/comment-action@v1
         with:
-          json_files: "reports/*.json"
+          api_key: ${{ secrets.MEMBROWSE_API_KEY }}
+          api_url: ${{ vars.MEMBROWSE_API_URL }}
+          commit: ${{ github.event.workflow_run.head_sha }}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/membrowse-onboard.yml
+++ b/.github/workflows/membrowse-onboard.yml
@@ -91,6 +91,7 @@ jobs:
           num_commits: ${{ github.event.inputs.num_commits }}
           build_script: /tmp/build.sh ${{ matrix.board }}
           elf: ${{ matrix.elf }}
+          map_file: ${{ matrix.map }}
           ld: ${{ matrix.ld }}
           linker_vars: ${{ matrix.linker_vars }}
           api_key: ${{ secrets.MEMBROWSE_API_KEY }}

--- a/.github/workflows/membrowse-report.yml
+++ b/.github/workflows/membrowse-report.yml
@@ -7,8 +7,8 @@ on:
       - main
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  group: ${{ github.workflow }}-${{ github.event_name == 'push' && github.sha || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   load-targets:
@@ -23,7 +23,7 @@ jobs:
         id: set-matrix
         run: echo "matrix=$(jq -c '.' .github/membrowse-targets.json)" >> $GITHUB_OUTPUT
 
-  build:
+  analyze:
     needs: load-targets
     runs-on: ubuntu-22.04
     container: espressif/idf:release-v5.5
@@ -49,55 +49,26 @@ jobs:
           done
           ${{ matrix.build_cmd }}
 
-      - name: Upload ELF artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: elf-${{ matrix.target_name }}
-          path: ${{ matrix.elf }}
-
-  analyze:
-    needs: [load-targets, build]
-    runs-on: ubuntu-22.04
-    strategy:
-      fail-fast: false
-      matrix:
-        include: ${{ fromJson(needs.load-targets.outputs.matrix) }}
-
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v5
-        with:
-          fetch-depth: 0
-
-      - name: Download ELF artifact
-        uses: actions/download-artifact@v4
-        with:
-          name: elf-${{ matrix.target_name }}
-          path: elf-download
-
-      - name: Prepare ELF path
-        id: elf
+      # ESP-IDF container lacks pip and enforces PEP 668; install pip
+      # and allow system-wide packages so membrowse-action can run.
+      # Also mark the workspace as a safe git directory globally so
+      # subprocess git calls from membrowse (which run without the
+      # checkout action's temporary HOME) can read commit metadata.
+      - name: Setup container for Membrowse
         run: |
-          mkdir -p $(dirname "${{ matrix.elf }}")
-          mv elf-download/*.elf "${{ matrix.elf }}"
-          echo "path=${{ matrix.elf }}" >> $GITHUB_OUTPUT
+          apt-get update && apt-get install -y python3-pip
+          python3 -m pip config set global.break-system-packages true
+          git config --global --add safe.directory "$GITHUB_WORKSPACE"
 
-      - name: Run Membrowse PR Action
-        id: analyze
+      - name: Run Membrowse Analysis
         continue-on-error: true
         uses: membrowse/membrowse-action@v1
         with:
           target_name: ${{ matrix.target_name }}
-          elf: ${{ steps.elf.outputs.path }}
+          elf: ${{ matrix.elf }}
+          map_file: ${{ matrix.map }}
           ld: ${{ matrix.ld }}
           linker_vars: ${{ matrix.linker_vars }}
           api_key: ${{ secrets.MEMBROWSE_API_KEY }}
           api_url: ${{ vars.MEMBROWSE_API_URL }}
           verbose: INFO
-
-      - name: Upload report artifact
-        if: ${{ steps.analyze.outcome == 'success' }}
-        uses: actions/upload-artifact@v4
-        with:
-          name: membrowse-report-${{ matrix.target_name }}
-          path: ${{ steps.analyze.outputs.report_path }}


### PR DESCRIPTION
There is an issue with the current MemBrowse integration and I'm offering a fix.

  The APIs of MemBrowse have improved, so uploading and downloading ELF artifacts between jobs is no longer necessary. The analyze job now builds and
  analyzes in one step, and the PR comment workflow fetches reports directly from the MemBrowse API using the workflow_run head SHA — removing a significant
   amount of artifact-shuffling glue code.                                                                                                                                                                                                                                                                                Map file support was also added, so it's now possible to see how different libraries contribute to the firmware size. Each target in
  membrowse-targets.json gained a map entry, and this is threaded through both the per-commit report workflow and the onboarding workflow.

  As a small side fix, the concurrency group for membrowse-report.yml is now keyed per-SHA on push, so builds on main are no longer cancelled by subsequent
  pushes while still cancelling superseded PR runs.

  Here is the dashboard of libssh from a fork: https://membrowse.com/public/membrowse/libssh